### PR TITLE
attempt to resolve issue#3

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -39,6 +39,9 @@ def extract_page_data(data)
 
       # Get more detailed information by going to the application detail page (but only if necessary)
       record["description"] = extract_description(info_url)
+      if record["description"] == "" 
+        record["description"] = row["applicationTypeDisplay"]
+      end
       #p record
       ScraperWiki.save_sqlite(['council_reference'], record)
 


### PR DESCRIPTION
logic in the file talks about only getting relevant data, tries to extract the description but does nothing if it gets no result.  from the original result dataset, applicationTypeDisplay appears always filled in, so if the description scraping returns nothing, use that instead.

it has been a long time since i've had a planning alerts dev environment up and running, so can't test properly.. but the description in the issue is pretty clear and logic is not that hard.. if someone checks my ruby syntax.. this should be a simple fix.

fwiw - i had a reason to reinstall slack, was marking all old posts as read and noticed the recent comment from James mentioning this and i had 5mins spare.. not going to lose sleep if this is discarded :)