### PR TITLE
Update scraper.rb

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -56,16 +56,18 @@ def applications_page(authority_id, start_row, headers)
       "https://www.spear.land.vic.gov.au/spear/api/v1/applications/#{application_id}/summary?publicView=true",
       headers: headers
     )
-
-    yield(
-      "council_reference" => a["spearReference"],
-      "address" => a["property"],
-      "description" => detail["data"]["intendedUse"],
-      "info_url" => "https://www.spear.land.vic.gov.au/spear/app/public/applications/#{application_id}/summary",
-      "date_scraped" => Date.today.to_s,
-      "date_received" => Date.strptime(a["submittedDate"], "%d/%m/%Y").to_s
-    )
-  end
+    if detail && detail["data"] 
+      yield(
+        "council_reference" => a["spearReference"],
+        "address" => a["property"],
+        "description" => detail["data"]["intendedUse"].to_s, # Converts nil to an empty string - avoid type mismatch
+        "info_url" => "https://www.spear.land.vic.gov.au/spear/app/public/applications/#{application_id}/summary",
+        "date_scraped" => Date.today.to_s,
+        "date_received" => Date.strptime(a["submittedDate"], "%d/%m/%Y").to_s
+      )
+    else
+      puts "Skipping #{a['spearReference']} due to missing detail data."
+end
 
   [applications["data"]["resultRows"].count, applications["data"]["numFound"]]
 end


### PR DESCRIPTION
Fix 'description' nil error and improve data checks in scraper.

NilClass errors when attempting to save applications without a description field. 

solution:
- Convert description to a string to handle nil values gracefully
- Check for the presence of detail and detail["data"] to avoid NoMethodError